### PR TITLE
Fixes #16 - Implement command line argument parsing using argly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Examples:
 
    Test a single file: "mocha-puppeteer /foo/bar-test.js"
 
-   Test a series of files using a glob pattern: "mocha-puppeteer /foo/**/*-test.js"
+   Test a series of files using a glob pattern: "mocha-puppeteer /foo/*/*-test.js"
 
 Options:
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,26 @@ You can also get test coverage information using `nyc`
 npx nyc mocha-puppeteer ./test/*.js
 ```
 
+All available options:
+
+```
+Usage: mocha-puppeteer [OPTIONS]
+
+Examples:
+
+   Test a single file: "mocha-puppeteer /foo/bar-test.js"
+
+   Test a series of files using a glob pattern: "mocha-puppeteer /foo/**/*-test.js"
+
+Options:
+
+     --help -h Show this help message [string]
+
+  --version -v Show the version number of mocha-puppeteer [string]
+
+--pattern -p * Pattern to run tests. Either a single file or glob pattern. [string]
+```
+
 ## Configuring the test file
 You can configure `mocha-puppeteer` with a `.mocha-puppeteer-config.js` file.
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,13 @@
 
 Since the release of Google Chrome headless mode, the Chrome DevTools team has developed
 [puppeteer](https://github.com/GoogleChrome/puppeteer) for running and managing an instance of Chromium.
-This module makes it possible to run tests written with
-[mocha](https://github.com/mochajs/mocha) inside of a Chromium instance.
-
-
-*Note:* Still under dev. Nothing is really configurable right now. Come back later.
+This module makes it possible to easily run tests written with [mocha](https://github.com/mochajs/mocha)
+inside of a Chromium instance. Module bundling is automatically handled using
+[lasso](https://github.com/lasso-js/lasso).
 
 ## Installation
 
-```
+```bash
 npm i -D mocha-puppeteer
 ```
 
@@ -23,9 +21,42 @@ npm i -D mocha-puppeteer
 To run your tests, you can pass in the test files to the exposed cli tool. A glob works too depending
 on the shell you are using.
 
+```bash
+npx mocha-puppeteer ./tests/dirA/*.js ./test/dirB/*.js
 ```
-npx mocha-puppeteer ./tests/*.js
+
+You can also get test coverage information using `nyc`
+
+```bash
+npx nyc mocha-puppeteer ./test/*.js
 ```
+
+## Configuring the test file
+You can configure `mocha-puppeteer` with a `.mocha-puppeteer-config.js` file.
+
+Example config file:
+
+```js
+require('require-self-ref')
+
+module.exports = {
+  lassoConfig: {
+    require: {
+      transforms: [
+        {
+          transform: require('lasso-babel-transform'),
+          config: {
+            extensions: ['.js', '.es6']
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+At the moment, only options for configuring `lasso` are supported with the `lassoConfig` field.
+Babel transforms can be applied using the [lasso-babel-transform](https://github.com/lasso-js/lasso-babel-transform) module.
 
 ## Contributing
 

--- a/bin/mocha-puppeteer
+++ b/bin/mocha-puppeteer
@@ -1,3 +1,11 @@
 #!/usr/bin/env node
+const cli = require('../cli')
 
-require('../cli')()
+;(async () => {
+  try {
+    await cli()
+  } catch (err) {
+    console.error(err)
+    process.exit(1)
+  }
+})()

--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,8 @@
+const argly = require('argly')
 const mochaPuppeteer = require('./index')
 const _loadConfig = require('./src/utils/loadConfig')
 
-const args = process.argv.slice(2)
+const mochaPuppeteerPkgVersion = require('./package.json').version
 
 // pick specific values from config
 function _pickConfig (config) {
@@ -11,7 +12,48 @@ function _pickConfig (config) {
   /* eslint-enable */
 }
 
+const parser = argly
+  .createParser({
+    '--help -h': {
+      type: 'string',
+      description: 'Show this help message'
+    },
+    '--version -v': {
+      type: 'string',
+      description: 'Show the version number of mocha-puppeteer'
+    },
+    '--pattern -p *': {
+      type: 'string',
+      description: 'Pattern to run tests. Either a single file or glob pattern.'
+    }
+  })
+  .example('Test a single file: "mocha-puppeteer /foo/bar-test.js"')
+  .example('Test a series of files using a glob pattern: "mocha-puppeteer /foo/*/*-test.js"')
+  .validate(function (result) {
+    if (result.help) {
+      this.printUsage()
+    } else if (result.version) {
+      console.log(`mocha-puppeteer@${mochaPuppeteerPkgVersion}`)
+    } else if (!result.pattern) {
+      this.printUsage()
+    }
+  })
+  .onError(function (err) {
+    this.printUsage()
+    throw new Error('Error parsing command line args: ', err)
+  })
+
 module.exports = async function runCli () {
+  const {
+    pattern,
+    help,
+    version
+  } = parser.parse()
+
+  // Gracefully exit if either the "help" or "version" arguments are supplied
+  // of if the "pattern" argument is missing because it's required.
+  if (help || version || !pattern) return
+
   try {
     const config = await _loadConfig({
       startingDirectory: process.cwd()
@@ -19,9 +61,7 @@ module.exports = async function runCli () {
 
     const options = config ? _pickConfig(config) : {}
 
-    Object.assign(options, {
-      testFiles: args
-    })
+    Object.assign(options, { testFiles: [ pattern ] })
 
     await mochaPuppeteer.runTests(options)
   } catch (err) {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "Charlie Duong",
   "license": "MIT",
   "dependencies": {
+    "argly": "^1.2.0",
     "babel-plugin-istanbul": "^4.1.4",
     "bluebird": "^3.5.0",
     "koa": "^2.3.0",


### PR DESCRIPTION
There are still more options I want to add, but this is a first pass. Specifically, I want to add more options related to [launch options](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions). It would be nice if you could specify the Chromium executable path. I will open up a separate issue to track this work.