### PR TITLE
Adding devtools flag.

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -85,6 +85,10 @@ const parser = argly
     '--puppeteerPageTimeout': {
       type: 'number',
       description: 'Maximum time in milliseconds to wait for the page to load'
+    },
+    '--devtools': {
+      type: 'boolean',
+      description: 'Turn on the Developer Tools support. Useful for debugging using the "debugger" keyword in your tests.'
     }
   })
   .example('Test a single file: "mocha-puppeteer /foo/bar-test.js"')
@@ -124,7 +128,8 @@ module.exports = async function runCli () {
     dumpio,
     userDataDir,
     puppeteerPageTimeout,
-    testPagePath
+    testPagePath,
+    devtools
   } = parser.parse()
 
   // Gracefully exit if either the "help" or "version" arguments are supplied
@@ -174,7 +179,8 @@ module.exports = async function runCli () {
         handleSIGINT,
         timeout: puppeteerTimeout,
         dumpio,
-        userDataDir
+        userDataDir,
+        devtools
       },
       puppeteerPageOptions: {
         timeout: puppeteerPageTimeout


### PR DESCRIPTION
This is super helpful if you wish to debug your scripts. You can do this by running the following.

```
npx mocha-puppeteer ./test.js --devtools
```

Then if you put the following in your scripts it will debug them.

```
debugger;
```